### PR TITLE
Vagrant update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # linux environment files
 .bash_history
+.bash_profile
 .cache
 .sudo_as_admin_successful
 .vagrant/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # linux environment files
 .bash_history
-.bash_profile
 .cache
 .sudo_as_admin_successful
 .vagrant/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# linux environment files
+.bash_history
+.cache
+.sudo_as_admin_successful
+.vagrant/
+.config
+.kube

--- a/README.md
+++ b/README.md
@@ -5,13 +5,15 @@
 - Initially, `hc_id_rsa` SSH Key will generate when you this script.
 - But it will prompt you to overwrite (y/n) for SSH Key if you've created before.
 - Secondly, highly recommened to specify your `VagrantBox SSH Key Path`, instead of using default path.
+- Option: you can comment off the other tools installation as you want.
 
 ```
 ./ssh-vagrant.sh
 ```
 
-
 #### Example input of SSH Key path
+![ssh-key-path](https://github.com/htoohtooaungcloud/Terraform/assets/54118047/8b7bf92b-201e-479b-9a76-01b8c6beece1)
+
 
 ### Spin-up the Kubernetes Cluster using Cilium as CNI
 - Go the manifests directory and run the scrip `setup-mlb-13-cilium-k8s-v127.sh`
@@ -19,10 +21,13 @@
 - However, if you wanna add more worker-nodes, go to he `/manitests/kind-cluster/kindconfig-v1270.yaml` file and configure.
 - Even though using the `Cilium` as CNI, Load-Balancer still using `Metallb` but Version is v.13.
 
+
 ```
 cd ~/manifests
 ./setup-mlb-13-cilium-k8s-v127.sh
 ```
+#### Up and running `Kubernetes Cluster` with `Cilium` and `Metallb`
+![cilium-k8s-metallb](https://github.com/htoohtooaungcloud/Terraform/assets/54118047/1dbceee0-ede0-48e6-95c1-d546d5d1f035)
 
 #### Create /etc/vbox/networks.conf
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,29 @@
 # hellocloud-native-box
 
+
+## Updated VagrantBox Spin-up using bash script
+- Initially, `hc_id_rsa` SSH Key will generate when you this script.
+- But it will prompt you to overwrite (y/n) for SSH Key if you've created before.
+- Secondly, highly recommened to specify your `VagrantBox SSH Key Path`, instead of using default path.
+
+```
+./ssh-vagrant.sh
+```
+
+
+#### Example input of SSH Key path
+
+### Spin-up the Kubernetes Cluster using Cilium as CNI
+- Go the manifests directory and run the scrip `setup-mlb-13-cilium-k8s-v127.sh`
+- Kubernetes Cluster will spin-up with one master-node and two worker-nodes.
+- However, if you wanna add more worker-nodes, go to he `/manitests/kind-cluster/kindconfig-v1270.yaml` file and configure.
+- Even though using the `Cilium` as CNI, Load-Balancer still using `Metallb` but Version is v.13.
+
+```
+cd ~/manifests
+./setup-mlb-13-cilium-k8s-v127.sh
+```
+
 #### Create /etc/vbox/networks.conf
 ```
 sudo su

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,51 +1,68 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+VAGRANT_SSH_PATH = ENV['VAGRANT_SSH_PATH'] || "/home/htoohtoo/hellocloud/hellocloud-native-box/.ssh/hc_id_rsa"
+
+VAGRANT_BOX_IMAGE = "bento/ubuntu-22.04"
+VAGRANT_BOX_NAME  = "hellocloud-native-box"
+CPUS_FOR_BOX      = 4
+MEMORY_FOR_BOX    = 8192
+BOX_IP_ADDRESS    = "192.168.56.85"
 
 Vagrant.configure("2") do |config|
-
-    config.vm.define "hellocloud-native-box" do |vm1|
-      config.ssh.private_key_path = "/Users/sai/hellocloud-boxes/hellocloud-native-box/.ssh/id_rsa"
-      config.ssh.forward_agent = true
-      config.ssh.username = "vagrant"
-      config.ssh.password = "vagrant"
-      vm1.vm.hostname = "hellocloud-native-box"
-      vm1.vm.box = "bento/ubuntu-22.04"
-      vm1.vm.network "private_network", ip: "192.168.56.85"
-      # vm1.vm.network "forwarded_port", guest: 8200, host: 8200
-      vm1.vm.synced_folder ".", "/home/vagrant/"
-      vm1.vm.provider "virtualbox" do |vb|
-        vb.name = "hellocloud-native-box"
-        vb.memory = "8192"
-        vb.cpus = 4
-        vb.gui = false
-      end
-  
-      vm1.vm.provision "shell", run: "always", inline: <<-SHELL
-        sudo apt-get update
-        sudo apt-get install net-tools zip curl jq tree unzip wget siege apt-transport-https ca-certificates software-properties-common gnupg lsb-release -y
-        netstat -tunlp
-        echo "Hello from hellocloud-native-box"
-      SHELL
-  
-      vm1.vm.provision "shell",
-        privileged: true,
-        path: './scripts/1-docker-install.sh'
-  
-      vm1.vm.provision "shell",
-        privileged: true,
-        path: './scripts/2-kubectl-install.sh'
-  
-      vm1.vm.provision "shell",
-        privileged: true,
-        path: './scripts/3-kind-install.sh'
-  
-      vm1.vm.provision "shell",
-        privileged: true,
-        path: './scripts/4-helm-install.sh'
-
-      vm1.vm.provision "shell",
-        privileged: true,
-        path: './scripts/8-grpcurl-install.sh'
+  config.vm.define VAGRANT_BOX_NAME do |vm1|
+    config.ssh.private_key_path = VAGRANT_SSH_PATH
+    config.ssh.forward_agent = true
+    config.ssh.username = "vagrant"
+    config.ssh.password = "vagrant"
+    vm1.vm.hostname = VAGRANT_BOX_NAME
+    vm1.vm.box = VAGRANT_BOX_IMAGE
+    vm1.vm.network "private_network", ip: BOX_IP_ADDRESS
+    vm1.vm.synced_folder ".", "/home/vagrant/"
+    vm1.vm.provider "virtualbox" do |vb|
+      vb.name = VAGRANT_BOX_NAME
+      vb.memory = MEMORY_FOR_BOX
+      vb.cpus = CPUS_FOR_BOX
+      vb.gui = false
     end
+
+    config.vm.provision "shell" do |s|
+      ssh_pub_key = File.readlines("#{VAGRANT_SSH_PATH}.pub").first.strip
+      s.inline = <<-SHELL
+        echo #{ssh_pub_key} >> /home/vagrant/.ssh/authorized_keys
+        echo "Successfully inserted SSH Public key"
+      SHELL
+    end
+
+    vm1.vm.provision "shell", run: "always", inline: <<-SHELL
+      sudo apt-get update
+      sudo apt-get install -y net-tools zip curl jq tree unzip wget siege apt-transport-https ca-certificates software-properties-common gnupg lsb-release
+      netstat -tunlp
+      echo "Hello from $VAGRANT_BOX_NAME"
+    SHELL
+
+    vm1.vm.provision "shell",
+      privileged: true,
+      path: './scripts/1-docker-install.sh'
+  
+    vm1.vm.provision "shell",
+      privileged: true,
+      path: './scripts/2-kubectl-install.sh'
+  
+    vm1.vm.provision "shell",
+      privileged: true,
+      path: './scripts/3-kind-install.sh'
+  
+    # vm1.vm.provision "shell",
+    #   privileged: true,
+    #   path: './scripts/4-helm-install.sh'
+
+    # vm1.vm.provision "shell",
+    #   privileged: true,
+    #   path: './scripts/8-grpcurl-install.sh'
+
+    vm1.vm.provision "shell",
+      privileged: true,
+      path: './scripts/10-cilium-install.sh'
   end
+end

--- a/manifests/kind-cluster/kindconfig-v1270.yaml
+++ b/manifests/kind-cluster/kindconfig-v1270.yaml
@@ -1,0 +1,21 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: istio-k8s-cluster
+nodes:
+- role: control-plane
+  image: kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72
+- role: worker
+  image: kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72
+- role: worker
+  image: kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72
+# - role: worker
+#   image: kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72
+# - role: worker
+#  image: kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72
+networking:
+  # apiServerAddress: 192.168.18.39
+  # apiServerPort: 6443
+  podSubnet: 10.240.0.0/16
+  serviceSubnet: 10.120.0.0/16
+  disableDefaultCNI: true
+  kubeProxyMode: none

--- a/manifests/setup-mlb-13-cilium-k8s-v127.sh
+++ b/manifests/setup-mlb-13-cilium-k8s-v127.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+sudo sysctl fs.inotify.max_user_watches=524288
+sudo sysctl fs.inotify.max_user_instances=512
+
+kind create cluster --config ~/manifests/kind-cluster/kindconfig-v1270.yaml
+sleep 2
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.9/config/manifests/metallb-native.yaml
+sleep 2
+cilium install
+sleep 2
+count=0
+echo
+
+pods_checking=false
+# Loop until the pods are running
+while ! $pods_checking; do
+    # Check if metallb-system pods are running and daemonsets "READY" state and "DESIRED" state must be equal
+    if kubectl get deployment controller -n metallb-system -o jsonpath='{.status.readyReplicas}' | \
+    grep -q "$(kubectl get deployment controller -n metallb-system -o jsonpath='{.status.availableReplicas}')" && \
+    kubectl get daemonsets -n metallb-system -o jsonpath='{.items[*].status.numberReady}' | \
+    grep -q "$(kubectl get daemonsets -n metallb-system -o jsonpath='{.items[*].status.desiredNumberScheduled}')" ; then
+        echo "Metallb-system deployment & daemonsets are running, proceeding to next step..."
+        sleep 5
+        echo "[Creating metallb IP-Address Pool]"
+        kubectl apply -f $HOME/manifests/kind-cluster/ippool-metallb.yaml # need to change the correct path
+        # Set the flag to true to exit the loop
+        pods_checking=true
+    else
+        sleep 2
+        while true; do
+            echo "Metallb-system deployment and daemonsets are not running, waiting for $count seconds..."
+            count=$((count + 1))
+                if ((count >= 5)); then
+                    break
+                fi
+            sleep 0.5
+        done
+    fi
+done
+
+sleep 0.5
+kubectl get ipaddresspools.metallb.io -n metallb-system
+kubectl get l2advertisements.metallb.io -n metallb-system
+sleep 1
+watch kubectl get pod -A

--- a/manifests/tear-down.sh
+++ b/manifests/tear-down.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+echo "[Running tear-down.sh]"
+
+kind delete clusters $(kind get clusters)
+kubectl config delete-context $(kubectl config get-contexts -o name)
+echo "====== Clean Up kubeconfig ====="
+cp -ar ~/scripts/config ~/.kube/
+cat ~/.kube/config
+echo "====== verify kind cluters ======"
+kind get clusters

--- a/ssh-vagrant.sh
+++ b/ssh-vagrant.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Define the SSH key output directory and file name
+KEY_DIR=./.ssh
+KEY_NAME=hc_id_rsa
+
+# Check if the directory exists, if not, create it
+if [ ! -d "$KEY_DIR" ]; then
+  mkdir -p "$KEY_DIR"
+  echo "Created directory $KEY_DIR"
+fi
+
+# Generate the SSH key pair
+ssh-keygen -t rsa -b 4096 -N "" -f "$KEY_DIR/$KEY_NAME"
+
+echo "[SSH key pair generated successfully]"
+echo "Private key: $KEY_DIR/$KEY_NAME"
+echo "Public key: $KEY_DIR/${KEY_NAME}.pub"
+
+# Prompt the user for the SSH key path
+echo "Please enter your SSH Key Path (Press enter for default path: $KEY_DIR/$KEY_NAME):"
+read -r input_ssh_path
+
+# Use the provided path or the default if no input was given
+VAGRANT_SSH_PATH=${input_ssh_path:-"$KEY_DIR/$KEY_NAME"}
+
+echo "[Using SSH Key Path: $VAGRANT_SSH_PATH]"
+
+# Spin up the Vagrant box with the SSH path environment variable
+VAGRANT_SSH_PATH="$VAGRANT_SSH_PATH" vagrant up


### PR DESCRIPTION
Hello, Ko Sai and Phoo Phoo.

**PR for  VagranBox installation Update.**

1. Update the initial setup using the bash script ssh-vagrant.sh, with the vagrant up command inside.
2. An SSH key will be generated once you run the script, but if an SSH key already exists, it will prompt to overwrite with y/n.
3. Spin up the Kubernetes Cluster using Cilium as the CNI, while still leveraging the Load-Balancer as MetalLB v0.13.9.a but must be SSH into the vagranbox and cd to "/home/vagrant/manifest" path

Appreciate your review and approval if the updates are valid.

**HtooHtoo (Cohort-3 Member)**
![ssh-key-path](https://github.com/hellocloudio/hellocloud-native-box/assets/54118047/fe44f42c-4c1f-41eb-a12d-a1a653925d75)
![cilium-k8s-metallb](https://github.com/hellocloudio/hellocloud-native-box/assets/54118047/fcb38910-8bc1-4742-ba45-0720de2d652e)
